### PR TITLE
Fix Cpu usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
     }
 
     maven {
-        url "http://nexus.theyeticave.net/content/repositories/pub_releases"
+        url "http://nexus.hc.to/content/repositories/pub_releases"
     }
 
 }

--- a/src/main/java/net/rymate/jpanel/getters/StatsGetter.java
+++ b/src/main/java/net/rymate/jpanel/getters/StatsGetter.java
@@ -40,9 +40,16 @@ public class StatsGetter extends GetterBase {
         OperatingSystemMXBean os = ManagementFactory.getOperatingSystemMXBean();
         int processors = os.getAvailableProcessors();
 
+        //system load is -1 if you use it with windows
         double usage = os.getSystemLoadAverage() / processors;
 
         long cpuUsage = Math.round(usage * 100.0D);
+
+        //works for all platforms, but only if the Oracle JRE/JDK is installed
+        if (os instanceof com.sun.management.OperatingSystemMXBean) {
+            com.sun.management.OperatingSystemMXBean oracleOs = (com.sun.management.OperatingSystemMXBean) os;
+            cpuUsage = (long) (oracleOs.getSystemCpuLoad() * 100);
+        }
 
         // shove in a hashmap
         Map map = new HashMap();


### PR DESCRIPTION
This fixes building due an outdated repository link and adds a new way to get the cpu usage. 

This uses some internal classes of the Oracle JDK/JRE version. If it wasn't found it will fallback to the old one. This one fixes showing the cpu usage if getSystemLoad returns -1 (i.e. Windows).